### PR TITLE
fix filetype blacklist being ignored

### DIFF
--- a/autoload/youcompleteme.vim
+++ b/autoload/youcompleteme.vim
@@ -391,7 +391,6 @@ endfunction
 
 
 function! s:AllowedToCompleteInBuffer( buffer )
-  return 1
   let buffer_filetype = getbufvar( a:buffer, '&filetype' )
 
   if empty( buffer_filetype ) ||

--- a/doc/youcompleteme.txt
+++ b/doc/youcompleteme.txt
@@ -2410,7 +2410,6 @@ Default: '[see next line]'
         \ 'tagbar' : 1,
         \ 'qf' : 1,
         \ 'notes' : 1,
-        \ 'markdown' : 1,
         \ 'unite' : 1,
         \ 'text' : 1,
         \ 'vimwiki' : 1,

--- a/third_party/ycmd/ycmd/default_settings.json
+++ b/third_party/ycmd/ycmd/default_settings.json
@@ -25,7 +25,7 @@
     "tagbar": 1,
     "qf": 1,
     "notes": 1,
-    "markdown": 1,
+    "TelescopePrompt": 1,
     "netrw": 1,
     "unite": 1,
     "text": 1,


### PR DESCRIPTION
# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Fix #75  basically restore the short-circuited (for no reason? need testing, works fine on my machine ) filetype blacklist

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
